### PR TITLE
Update listen tags through playlist parameters

### DIFF
--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -427,7 +427,7 @@ extension Playlist {
     }
 
     public var inSpeakerRange: Bool {
-        if let params = currentParams {
+        if currentParams != nil {
             return distanceToNearestSpeaker <= project.out_of_range_distance
         } else {
             return false
@@ -513,9 +513,9 @@ extension Playlist {
 
     private func updateTrackParams() {
         if let params = currentParams {
-            // update all tracks in parallel, in case they need to load a new track
+            // update all tracks in parallel, in case they need to load a new asset
             for t in tracks {
-                Promise<Void>(on: .global()) {
+                _ = Promise<Void>(on: .global()) {
                     t.updateParams(params)
                 }
             }

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -11,26 +11,28 @@ struct UserAssetData {
     let playCount: Int
 }
 
-class StreamParams {
+public class StreamParams {
     let location: CLLocation
     let minDist: Double?
     let maxDist: Double?
     let heading: Double?
     let angularWidth: Double?
+    let tags: [Int]?
     
-    init(location: CLLocation, minDist: Double?, maxDist: Double?, heading: Double?, angularWidth: Double?) {
+    init(location: CLLocation, minDist: Double?, maxDist: Double?, heading: Double?, angularWidth: Double?, tags: [Int]?) {
         self.location = location
         self.minDist = minDist
         self.maxDist = maxDist
         self.heading = heading
         self.angularWidth = angularWidth
+        self.tags = tags
     }
 }
 
 public class Playlist {
     // server communication
     private var updateTimer: Repeater?
-    private(set) var currentParams: StreamParams?
+    public private(set) var currentParams: StreamParams?
     private(set) var startTime = Date()
 
     // assets and filters

--- a/RWFramework/RWFramework/Playlist/Playlist.swift
+++ b/RWFramework/RWFramework/Playlist/Playlist.swift
@@ -18,7 +18,7 @@ public class StreamParams {
     let heading: Double?
     let angularWidth: Double?
     let tags: [Int]?
-    
+
     init(location: CLLocation, minDist: Double?, maxDist: Double?, heading: Double?, angularWidth: Double?, tags: [Int]?) {
         self.location = location
         self.minDist = minDist
@@ -533,16 +533,20 @@ extension Playlist {
                 && asset.file != nil
         }.map { asset in
             (asset, self.filters.keep(asset, playlist: self, track: track))
-        }.filter { asset, rank in
+        }.filter { _, rank in
             rank != .discard
         }
 
-        return filteredAssets.min { a, b in
+        let asset = filteredAssets.min { a, b in
             // play less played assets first
             let playsOfA = userAssetData[a.0.id]?.playCount ?? 0
             let playsOfB = userAssetData[b.0.id]?.playCount ?? 0
             return playsOfA <= playsOfB && a.1.rawValue > b.1.rawValue
         }?.0
+
+        print("playing asset with tags \(asset?.tags)")
+
+        return asset
     }
 }
 
@@ -625,6 +629,8 @@ extension Playlist {
     /// Framework should call this when stream parameters are updated.
     func updateParams(_ opts: StreamParams) {
         currentParams = opts
+
+        print("playlist tags: \(currentParams?.tags)")
 
         if let heading = opts.heading {
             audioMixer.listenerAngularOrientation = AVAudio3DAngularOrientation(

--- a/RWFramework/RWFramework/RWFramework.swift
+++ b/RWFramework/RWFramework/RWFramework.swift
@@ -38,7 +38,8 @@ open class RWFramework: NSObject {
         minDist: nil,
         maxDist: nil,
         heading: nil,
-        angularWidth: nil
+        angularWidth: nil,
+        tags: nil
     )
     var lastRecordedLocation: CLLocation {
         return streamOptions.location

--- a/RWFramework/RWFramework/RWFrameworkAPI.swift
+++ b/RWFramework/RWFramework/RWFrameworkAPI.swift
@@ -21,8 +21,8 @@ extension RWFramework {
             .then { data in try self.setupClientSession(data) }
             .recover { _ -> Project in
                 // If offline, just fall back to saved project data.
-                let dict = RWFrameworkConfig.getConfigDataFromGroup(.project) as! [String: AnyObject]
-                let json = try JSONSerialization.data(withJSONObject: dict, options: [])
+                let dict = RWFrameworkConfig.getConfigDataFromGroup(.project) as? [String: AnyObject]
+                let json = try JSONSerialization.data(withJSONObject: dict ?? [:], options: [])
                 return try RWFramework.decoder.decode(Project.self, from: json)
             }
     }

--- a/RWFramework/RWFramework/RWFrameworkCoreLocation.swift
+++ b/RWFramework/RWFramework/RWFrameworkCoreLocation.swift
@@ -34,14 +34,16 @@ extension RWFramework: CLLocationManagerDelegate {
         location: CLLocation? = nil,
         range: ClosedRange<Double>? = nil,
         headingAngle: Double? = nil,
-        angularWidth: Double? = nil
+        angularWidth: Double? = nil,
+        tags: [Int]? = nil
     ) {
         streamOptions = StreamParams(
             location: location ?? streamOptions.location,
             minDist: range?.lowerBound ?? streamOptions.minDist,
             maxDist: range?.upperBound ?? streamOptions.maxDist,
             heading: headingAngle ?? streamOptions.heading,
-            angularWidth: angularWidth ?? streamOptions.angularWidth
+            angularWidth: angularWidth ?? streamOptions.angularWidth,
+            tags: tags ?? streamOptions.tags
         )
         playlist.updateParams(streamOptions)
     }

--- a/RWFramework/RWFramework/RWFrameworkTags.swift
+++ b/RWFramework/RWFramework/RWFrameworkTags.swift
@@ -284,11 +284,9 @@ extension RWFramework {
         return enabledListenTagIDs().contains(tagId)
     }
 
-    internal func enabledListenTagIDs() -> [Int] {
+    public func enabledListenTagIDs() -> [Int] {
         if let tags = playlist.currentParams?.tags, !tags.isEmpty {
             return tags
-        } else if let array = UserDefaults.standard.object(forKey: "listenIDsSet") as? [Int] {
-            return array
         } else if let uiconfig = getUIConfig() {
             var set = [Int]()
             for listen in uiconfig.listen {

--- a/RWFramework/RWFramework/RWFrameworkTags.swift
+++ b/RWFramework/RWFramework/RWFrameworkTags.swift
@@ -275,32 +275,32 @@ extension RWFramework {
         return tag_ids
     }
 
-    public func getSubmittableListenTagIDsSet() -> Set<Int>? {
-        var tag_ids: Set<Int> = []
-        if let selectedIDs = getListenIDsSet() {
-            for id in selectedIDs {
-                let tag_id = getListenTagIDFromID(id)
-                tag_ids.insert(tag_id)
-            }
-        }
-        return tag_ids
+    public func getSubmittableListenTagIDsSet() -> Set<Int> {
+        // Return the user selected tag list, or fallback to the default tag selection.
+        return Set(enabledListenTagIDs())
     }
 
-    public func tagIsEnabled(_ requestedTag: Int) -> Bool {
-        if let array = UserDefaults.standard.object(forKey: "listenIDsSet") as? [Int] {
-            return array.contains(requestedTag)
-        } else {
-            if let uiconfig = getUIConfig() {
-                for listen in uiconfig.listen {
-                    for item in listen.display_items {
-                        if item.default_state == true, item.tag_id == requestedTag {
-                            return true
-                        }
+    internal func tagIsEnabled(_ tagId: Int) -> Bool {
+        return enabledListenTagIDs().contains(tagId)
+    }
+
+    internal func enabledListenTagIDs() -> [Int] {
+        if let tags = playlist.currentParams?.tags, !tags.isEmpty {
+            return tags
+        } else if let array = UserDefaults.standard.object(forKey: "listenIDsSet") as? [Int] {
+            return array
+        } else if let uiconfig = getUIConfig() {
+            var set = [Int]()
+            for listen in uiconfig.listen {
+                for item in listen.display_items {
+                    if item.default_state == true {
+                        set.append(item.tag_id)
                     }
                 }
             }
-            return false
+            return set
         }
+        return []
     }
 
     public func getListenIDsSet() -> Set<Int>? {

--- a/RWFramework/RWFramework/RWFrameworkTimers.swift
+++ b/RWFramework/RWFramework/RWFrameworkTimers.swift
@@ -20,7 +20,6 @@ extension RWFramework {
             soundRecorder!.updateMeters()
             rwRecordingProgress(percentage, maxDuration: max_recording_length, peakPower: soundRecorder!.peakPower(forChannel: 0), averagePower: soundRecorder!.averagePower(forChannel: 0))
         } else if isPlayingBack() {
-            let soundRecorder = recorder.soundRecorder
             percentage = soundPlayer!.currentTime/soundPlayer!.duration
             soundPlayer!.updateMeters()
             rwPlayingBackProgress(percentage, duration: soundPlayer!.duration, peakPower: soundPlayer!.peakPower(forChannel: 0), averagePower: soundPlayer!.averagePower(forChannel: 0))


### PR DESCRIPTION
Instead of relying on UserDefaults to hold the right listen tags value, we allow application code to pass a list of tag IDs directly to the playlist. This simplifies the code and pushes handling of persisting user selection between launches to the app code.